### PR TITLE
Vulnerability Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Updated
+- isuftin@usgs.gov - Updated the version constraint for pyca/cryptography due to
+CVE https://nvd.nist.gov/vuln/detail/CVE-2018-10903
+
 ### Added
 - Dockerfile Healthcheck
 
@@ -22,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.4.0] - 2017-11-01
 ### Change
 - Trim whitespace from coordinateDatumCode before using it as a key to determine what projection to use.
- 
+
 ## [0.3.0] - 2017-10-18
 ### Change
 - Handle bad latitude/longitude values including out of range values by return null values for decimalLatitude and decimalLongitude.
@@ -38,5 +43,3 @@ decimalLatitude and decimalLongitude. Values will be null if invalid latitude, l
 [0.5.0]: https://github.com/USGS-CIDA/MLR-Legacy-Transformer/compare/MLR-Legacy-Transformer-0.4.0...MLR-Legacy-Transformer-0.5.0
 [0.4.0]: https://github.com/USGS-CIDA/MLR-Legacy-Transformer/compare/MLR-Legacy-Transformer-0.3.0...MLR-Legacy-Transformer-0.4.0
 [0.3.0]: https://github.com/USGS-CIDA/MLR-Legacy-Transformer/compare/MLR-Legacy-Transformer-0.2.0...MLR-Legacy-Transformer-0.3.0
- 
- 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi==2017.11.5
 cffi==1.11.2
 chardet==3.0.4
 click==6.7
-cryptography==2.1.3
+cryptography>=2.3
 Flask==0.12.2
 Flask-JWT-Simple==0.0.3
 flask-restplus==0.10.1


### PR DESCRIPTION
- isuftin@usgs.gov - Updated the version constraint for pyca/cryptography due to
CVE https://nvd.nist.gov/vuln/detail/CVE-2018-10903