### PR TITLE
MLR-323

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Change
+- cschroedl@usgs.gov - made services return all passed-in attributes instead of swallowing them.
+
 ### Updated
 - isuftin@usgs.gov - Updated the version constraint for pyca/cryptography due to
 CVE https://nvd.nist.gov/vuln/detail/CVE-2018-10903

--- a/services.py
+++ b/services.py
@@ -74,9 +74,18 @@ class DecimalLocation(Resource):
     def post(self):
         request_body = request.get_json()
         _handle_missing_keys(request_body, expected_lat_lon_model_keys)
-        return transform_location_to_decimal_location(request_body.get('latitude'),
-                                                      request_body.get('longitude'),
-                                                      request_body.get('coordinateDatumCode'))
+
+        transformed_attributes = transform_location_to_decimal_location(
+            request_body.get('latitude'),
+            request_body.get('longitude'),
+            request_body.get('coordinateDatumCode')
+        )
+
+        merged_attributes = {
+            **request_body,
+            **transformed_attributes
+        }
+        return merged_attributes, 200
 
 
 @api.route('/transformer/station_ix')
@@ -92,7 +101,12 @@ class StationIx(Resource):
         request_body = request.get_json()
         _handle_missing_keys(request_body, expected_station_name_model_keys)
         station_ix = re.sub('\s|[^a-zA-Z0-9]', '', request_body.get('stationName'))
-        return {'stationIx': station_ix.upper()}, 200
+        transformed_attributes = {'stationIx': station_ix.upper()}
+        merged_attributes = {
+            **request_body,
+            **transformed_attributes
+        }
+        return merged_attributes, 200
 
 
 version_model = api.model('VersionModel', {

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -22,15 +22,22 @@ class DecimalLocationTestCase(TestCase):
     def test_good_request(self, mock):
         good_token = jwt.encode({'authorities': ['one_role', 'two_role']}, 'secret')
         mock.return_value = {'decimalLatitude' : 40, 'decimalLongitude': -100}
+        input = {
+            'latitude': ' 400000    ',
+            'longitude': ' 1000000    ',
+            'coordinateDatumCode': 'NAD27      ',
+        }
         response = self.app_client.post('/transformer/decimal_location',
                                         content_type='application/json',
                                         headers={'Authorization': 'Bearer {0}'.format(good_token.decode('utf-8'))},
-                                        data=json.dumps({
-                                            'latitude': ' 400000    ',
-                                            'longitude' : ' 1000000    ',
-                                            'coordinateDatumCode' : 'NAD27      '}))
+                                        data=json.dumps(input))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.data), {'decimalLatitude' : 40, 'decimalLongitude': -100})
+        expected = {
+            **input,
+            'decimalLatitude': 40,
+            'decimalLongitude': -100,
+        }
+        self.assertEqual(expected, json.loads(response.data))
 
     def test_missing_keys(self, mock):
         good_token = jwt.encode({'authorities': ['one_role', 'two_role']}, 'secret')
@@ -78,21 +85,31 @@ class StationIxTestCase(TestCase):
 
     def test_station_name_with_whitespace(self):
         good_token = jwt.encode({'authorities': ['one_role', 'two_role']}, 'secret')
+        input = {"stationName": "Station Name"}
         response = self.app_client.post('/transformer/station_ix',
                                         content_type='application/json',
                                         headers={'Authorization': 'Bearer {0}'.format(good_token.decode('utf-8'))},
-                                        data='{"stationName": "Station Name"}')
+                                        data=json.dumps(input))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.data), {'stationIx': 'STATIONNAME'})
+        expected = {
+            **input,
+            'stationIx': 'STATIONNAME',
+        }
+        self.assertEqual(json.loads(response.data), expected)
 
     def test_station_name_with_nonalphanumerics(self):
         good_token = jwt.encode({'authorities': ['one_role', 'two_role']}, 'secret')
+        input = {"stationName": "Station#_Name1$"}
         response = self.app_client.post('/transformer/station_ix',
                                         content_type='application/json',
                                         headers={'Authorization': 'Bearer {0}'.format(good_token.decode('utf-8'))},
-                                        data='{"stationName": "Station#_Name1$"}')
+                                        data=json.dumps(input))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.data), {'stationIx': 'STATIONNAME1'})
+        expected = {
+            **input,
+            'stationIx': 'STATIONNAME1',
+        }
+        self.assertEqual(expected, json.loads(response.data))
 
     def test_invalid_request_payload(self):
         good_token = jwt.encode({'authorities': ['one_role', 'two_role']}, 'secret')


### PR DESCRIPTION
Context:
The Gateway's unit tests and implementations have different expectations than what the Transformer services actually return. Whereas the gateway's implementation and [unit test mocks](https://github.com/USGS-CIDA/MLR-Gateway/blob/master/src/test/java/gov/usgs/wma/mlrgateway/service/LegacyTransformerServiceTest.java#L48) suggest that the transformer services will return all passed-in attributes, the transformer services actual only return a handful of attributes. To make them consistent with each other, we could either: 1) update the Gateway's implementation and unit test mocks, or 2) adjust the transformer services' behavior. 

I can see compelling advantages and disadvantages for both approaches. The slightly more expedient option is to change the transformer services, so that's what I propose here. The transformer services' new contract is that they return all passed-in attributes instead of swallowing them. If it's better to close this PR and pursue option 1), please let me know.