### PR TITLE
Revert "MLR-323"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Change
-- cschroedl@usgs.gov - made services return all passed-in attributes instead of swallowing them.
-
 ### Updated
 - isuftin@usgs.gov - Updated the version constraint for pyca/cryptography due to
 CVE https://nvd.nist.gov/vuln/detail/CVE-2018-10903

--- a/services.py
+++ b/services.py
@@ -74,18 +74,9 @@ class DecimalLocation(Resource):
     def post(self):
         request_body = request.get_json()
         _handle_missing_keys(request_body, expected_lat_lon_model_keys)
-
-        transformed_attributes = transform_location_to_decimal_location(
-            request_body.get('latitude'),
-            request_body.get('longitude'),
-            request_body.get('coordinateDatumCode')
-        )
-
-        merged_attributes = {
-            **request_body,
-            **transformed_attributes
-        }
-        return merged_attributes, 200
+        return transform_location_to_decimal_location(request_body.get('latitude'),
+                                                      request_body.get('longitude'),
+                                                      request_body.get('coordinateDatumCode'))
 
 
 @api.route('/transformer/station_ix')
@@ -101,12 +92,7 @@ class StationIx(Resource):
         request_body = request.get_json()
         _handle_missing_keys(request_body, expected_station_name_model_keys)
         station_ix = re.sub('\s|[^a-zA-Z0-9]', '', request_body.get('stationName'))
-        transformed_attributes = {'stationIx': station_ix.upper()}
-        merged_attributes = {
-            **request_body,
-            **transformed_attributes
-        }
-        return merged_attributes, 200
+        return {'stationIx': station_ix.upper()}, 200
 
 
 version_model = api.model('VersionModel', {

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -22,22 +22,15 @@ class DecimalLocationTestCase(TestCase):
     def test_good_request(self, mock):
         good_token = jwt.encode({'authorities': ['one_role', 'two_role']}, 'secret')
         mock.return_value = {'decimalLatitude' : 40, 'decimalLongitude': -100}
-        input = {
-            'latitude': ' 400000    ',
-            'longitude': ' 1000000    ',
-            'coordinateDatumCode': 'NAD27      ',
-        }
         response = self.app_client.post('/transformer/decimal_location',
                                         content_type='application/json',
                                         headers={'Authorization': 'Bearer {0}'.format(good_token.decode('utf-8'))},
-                                        data=json.dumps(input))
+                                        data=json.dumps({
+                                            'latitude': ' 400000    ',
+                                            'longitude' : ' 1000000    ',
+                                            'coordinateDatumCode' : 'NAD27      '}))
         self.assertEqual(response.status_code, 200)
-        expected = {
-            **input,
-            'decimalLatitude': 40,
-            'decimalLongitude': -100,
-        }
-        self.assertEqual(expected, json.loads(response.data))
+        self.assertEqual(json.loads(response.data), {'decimalLatitude' : 40, 'decimalLongitude': -100})
 
     def test_missing_keys(self, mock):
         good_token = jwt.encode({'authorities': ['one_role', 'two_role']}, 'secret')
@@ -85,31 +78,21 @@ class StationIxTestCase(TestCase):
 
     def test_station_name_with_whitespace(self):
         good_token = jwt.encode({'authorities': ['one_role', 'two_role']}, 'secret')
-        input = {"stationName": "Station Name"}
         response = self.app_client.post('/transformer/station_ix',
                                         content_type='application/json',
                                         headers={'Authorization': 'Bearer {0}'.format(good_token.decode('utf-8'))},
-                                        data=json.dumps(input))
+                                        data='{"stationName": "Station Name"}')
         self.assertEqual(response.status_code, 200)
-        expected = {
-            **input,
-            'stationIx': 'STATIONNAME',
-        }
-        self.assertEqual(json.loads(response.data), expected)
+        self.assertEqual(json.loads(response.data), {'stationIx': 'STATIONNAME'})
 
     def test_station_name_with_nonalphanumerics(self):
         good_token = jwt.encode({'authorities': ['one_role', 'two_role']}, 'secret')
-        input = {"stationName": "Station#_Name1$"}
         response = self.app_client.post('/transformer/station_ix',
                                         content_type='application/json',
                                         headers={'Authorization': 'Bearer {0}'.format(good_token.decode('utf-8'))},
-                                        data=json.dumps(input))
+                                        data='{"stationName": "Station#_Name1$"}')
         self.assertEqual(response.status_code, 200)
-        expected = {
-            **input,
-            'stationIx': 'STATIONNAME1',
-        }
-        self.assertEqual(expected, json.loads(response.data))
+        self.assertEqual(json.loads(response.data), {'stationIx': 'STATIONNAME1'})
 
     def test_invalid_request_payload(self):
         good_token = jwt.encode({'authorities': ['one_role', 'two_role']}, 'secret')


### PR DESCRIPTION
Reverts USGS-CIDA/MLR-Legacy-Transformer#18
This was a hack. The bug in the Gateway has been fixed, so we shouldn't need it anymore.