### PR TITLE
Standardizing Error Messages

### DIFF
--- a/config.py
+++ b/config.py
@@ -15,3 +15,6 @@ JWT_ALGORITHM = os.getenv('jwt_algorithm', 'HS256')
 
 # Set the JWT_DECODE_AUDIENCE environment variable to the value of the 'aud' claim in the
 JWT_DECODE_AUDIENCE = os.getenv('jwt_decode_audience')
+
+# Configure exception JSON to not always output with a `message` field. Global exception handling is done via a custom handler in services.py.
+ERROR_INCLUDE_MESSAGE=False

--- a/flask_restplus_jwt.py
+++ b/flask_restplus_jwt.py
@@ -2,10 +2,8 @@ from functools import wraps
 
 from flask import current_app, jsonify
 from flask_jwt_simple import JWTManager, jwt_required as simple_jwt_required, get_jwt
-from flask_jwt_simple.exceptions import NoAuthorizationError, InvalidHeaderError
-
-from jwt.exceptions import ExpiredSignatureError, DecodeError, InvalidAudienceError
-
+from flask_jwt_simple.exceptions import NoAuthorizationError
+from jwt.exceptions import InvalidTokenError
 
 
 class JWTRestplusManager(JWTManager):
@@ -26,10 +24,19 @@ class JWTRestplusManager(JWTManager):
         # https://github.com/vimalloc/flask-jwt-extended/issues/86
         self._set_error_handler_callbacks(api)
 
-        # Override default error handlers
+        # As a result of https://github.com/noirbizarre/flask-restplus/issues/421 we must register
+        # the invalid token error handler for each sub-class of jwt.exceptions.InvalidTokenError
+        def handle_invalid_token_error(e):
+            return self._invalid_token_callback(str(e))
+
+        for subclass in InvalidTokenError.__subclasses__():
+            (api.errorhandler(subclass))(handle_invalid_token_error)
+
+        # Override default error callbacks
         self.expired_token_loader(expired_token_callback)
         self.invalid_token_loader(invalid_token_callback)
         self.unauthorized_loader(unauthorized_callback)
+
 
 # Slightly tweaked version of the default callback from flask_jwt_simple.default_callbacks
 def expired_token_callback():
@@ -57,7 +64,7 @@ def jwt_required(fn):
     return wrapper
 
 
-def jwt_role_required(role):
+def jwt_role_required(allowed_roles):
     """
     Decorator for Flask Restplu resource view function which authenticates the authorization token and
     authories the token by matching the role against the role found in the JWT token.
@@ -72,18 +79,11 @@ def jwt_role_required(role):
         def wrapper(*args, **kwargs):
             response = simple_jwt_required(fn)(*args, **kwargs)
             token = get_jwt()
-            try:
-                if current_app.config['JWT_ROLE_CLAIM'](token) == role:
-                    return response
-                else:
-                    raise NoAuthorizationError('Does not have required role')
-            except KeyError:
+            roles_in_token = current_app.config['JWT_ROLE_CLAIM'](token)
+            if [role for role in roles_in_token if role in allowed_roles]:
+                return response
+            else:
                 raise NoAuthorizationError('Does not have required role')
         return wrapper
     return decorator
-
-
-
-
-
-
+    

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ click==6.7
 cryptography>=2.3
 Flask==0.12.3
 Flask-JWT-Simple==0.0.3
-flask-restplus==0.10.1
+flask-restplus==0.12.1
 idna==2.6
 itsdangerous==0.24
 Jinja2==2.9.6


### PR DESCRIPTION
Changes:

Previously error messages came in several formats:

```
{"msg": "<message>"} --> For JWT/Auth exceptions
{"message": "<message>"} --> For uncaught exceptions
{"error_message": "<message>"} --> For caught exceptions
```

This PR standardizes all of the above cases to the `{"error_message": "<message>"}` format.